### PR TITLE
fix: Test isolation for tracker tests

### DIFF
--- a/tests/test_tracked_jobs_ui.py
+++ b/tests/test_tracked_jobs_ui.py
@@ -108,17 +108,18 @@ def test_filter_tracked_jobs_by_status(client, mock_search_response):
     """Test that tracked jobs can be filtered by status (client-side filtering test via API)."""
     # Explicitly clear any existing tracked jobs to ensure clean state
     import os
-    from pathlib import Path
 
     import app.job_tracker as job_tracker_module
 
-    tracking_files = [
-        Path("job_tracking.json"),
-        Path("/app/data/job_tracking.json"),
-    ]
-    for tracking_file in tracking_files:
-        if tracking_file.exists():
-            os.remove(tracking_file)
+    # Force re-initialization of tracker to ensure clean state
+    job_tracker_module._tracker = None
+
+    # Get the actual tracking file path from the module
+    tracking_file = job_tracker_module.TRACKING_FILE
+    if tracking_file.exists():
+        os.remove(tracking_file)
+
+    # Re-initialize the tracker
     job_tracker_module._tracker = None
 
     # Track two jobs with different statuses using mocked responses


### PR DESCRIPTION
Fixes the failing test_filter_tracked_jobs_by_status test on main branch.

## Problem
Test was failing with 'Expected 1 applied job, got 2' because the clean_tracker fixture wasn't properly isolating between tests in the same xdist group.

## Root Cause
test_tracked_jobs_endpoint_returns_all_jobs creates 3 APPLIED jobs that leak into test_filter_tracked_jobs_by_status, even though both have @pytest.mark.xdist_group(name='tracker').

## Solution
Added explicit database cleanup at the start of test_filter_tracked_jobs_by_status to ensure clean state.

## Testing
This fixes the failing CI test on main branch.