### PR TITLE
feat: Add PowerShell git branch cleanup aliases

### DIFF
--- a/tools/git-aliases.ps1
+++ b/tools/git-aliases.ps1
@@ -1,0 +1,22 @@
+# Git Aliases and Helper Functions for PowerShell
+# Source this file in your PowerShell profile or run it in your session
+
+# Delete all local branches except main (safe - only deletes merged branches)
+function git-clean-branches {
+    git branch | Where-Object { $_ -notmatch 'main|\*' } | ForEach-Object { git branch -d $_.Trim() }
+}
+
+# Delete all local branches except main (force - deletes even unmerged branches)
+function git-clean-branches-force {
+    git branch | Where-Object { $_ -notmatch 'main|\*' } | ForEach-Object { git branch -D $_.Trim() }
+}
+
+# Preview what branches would be deleted
+function git-list-branches-to-clean {
+    git branch | Where-Object { $_ -notmatch 'main|\*' } | ForEach-Object { $_.Trim() }
+}
+
+# Usage:
+# git-list-branches-to-clean    # Preview branches that would be deleted
+# git-clean-branches             # Delete merged branches (safe)
+# git-clean-branches-force       # Delete all branches including unmerged (dangerous)


### PR DESCRIPTION
﻿Adds tools/git-aliases.ps1 with helper functions for cleaning up local branches.

**Functions:**
- git-clean-branches: Delete merged branches (safe)
- git-clean-branches-force: Delete all branches except main (force)
- git-list-branches-to-clean: Preview what would be deleted

PowerShell equivalent of Linux command: git branch -d dollar-sign(git branch | egrep -v main)

**Usage:**
``powershell
. tools/git-aliases.ps1
git-list-branches-to-clean    # Preview
git-clean-branches             # Safe delete
``
