### PR TITLE
[AI] Fix Ollama timeout in AI PR review workflow

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -224,11 +224,23 @@ jobs:
           if [ -z "$REVIEW_OUTPUT" ] || [ "$REVIEW_OUTPUT" = "" ]; then
             if [ -n "$OLLAMA_BASE_URL" ]; then
               echo "Attempting review with local Ollama..."
-              REVIEW_OUTPUT=$(curl -s "$OLLAMA_BASE_URL/api/generate" -d "{
+              # Add timeout and better error handling
+              API_RESPONSE=$(curl -s --max-time 120 "$OLLAMA_BASE_URL/api/generate" -d "{
                 \"model\": \"deepseek-coder:6.7b\",
                 \"prompt\": $(cat review_prompt.txt | jq -Rs .),
                 \"stream\": false
-              }" | jq -r '.response' 2>&1 || echo "")
+              }" 2>&1 || echo "")
+
+              # Save response for debugging
+              echo "$API_RESPONSE" > ollama_response.json
+
+              # Only parse if we got valid JSON
+              if echo "$API_RESPONSE" | jq -e '.response' > /dev/null 2>&1; then
+                REVIEW_OUTPUT=$(echo "$API_RESPONSE" | jq -r '.response')
+              else
+                echo "⚠️ Ollama Error or Timeout: $API_RESPONSE"
+                REVIEW_OUTPUT=""
+              fi
             fi
           fi
 


### PR DESCRIPTION
## Problem

The AI PR review workflow fails with a jq parse error when:
- Gemini API quota is exceeded (free tier limit)
- OpenAI API fallback fails (wrong API key)
- Ollama curl command hangs/times out without proper timeout

**Error seen:**
```
jq: parse error: Invalid numeric literal at line 1, column 10
```

## Root Cause

The Ollama curl command had no timeout and didn't validate the response before piping to jq:
```bash
curl -s "$OLLAMA_BASE_URL/api/generate" ... | jq -r '.response' 2>&1
```

When Ollama is unreachable or returns an error, jq receives invalid JSON and the error becomes the review output.

## Solution

1. **Add 120s timeout** to prevent indefinite hanging
2. **Save Ollama response** to `ollama_response.json` for debugging
3. **Validate JSON** before parsing with jq
4. **Display helpful error** when Ollama fails instead of cryptic jq errors

## Changes

- Add `--max-time 120` to curl command
- Check if response contains valid JSON with `.response` field
- Only parse if validation succeeds
- Show clear error message on failure

## Testing

- Workflow will now timeout after 2 minutes instead of hanging
- Invalid Ollama responses won't crash jq
- Error messages will be clear and actionable

Fixes the issue observed in PR #74 AI review run.

---
AI-Generated-By: GitHub Copilot (Claude Sonnet 4.5)
