### PR TITLE
[AI] Fix flaky test: test_cli_prints_sdk_name

### DIFF
--- a/tests/test_gemini_cli.py
+++ b/tests/test_gemini_cli.py
@@ -304,10 +304,13 @@ class TestGeminiCliOutput:
 
                 with patch.dict("sys.modules", {"google.genai": mock_genai, "google": MagicMock()}):
                     import importlib
+                    import sys
 
                     from app import gemini_cli
 
-                    importlib.reload(gemini_cli)
+                    # Ensure module is in sys.modules before reloading
+                    if "app.gemini_cli" in sys.modules:
+                        importlib.reload(gemini_cli)
                     gemini_cli.main()
 
                     # Capture and verify stdout contains SDK name


### PR DESCRIPTION
## Issue

The \	est_cli_prints_sdk_name\ test was failing intermittently in CI when running with pytest-xdist parallel execution:

\\\
ImportError: module app.gemini_cli not in sys.modules
\\\

## Root Cause

The test imports \gemini_cli\ inside a patched context, then tries to reload it with \importlib.reload()\. However, when tests run in parallel, the module might not be in \sys.modules\ yet, causing the reload to fail.

## Fix

Check if \'app.gemini_cli'\ exists in \sys.modules\ before attempting to reload it. This makes the test resilient to the import order in parallel test execution.

\\\python
# Before
importlib.reload(gemini_cli)

# After
if 'app.gemini_cli' in sys.modules:
    importlib.reload(gemini_cli)
\\\

## Testing

-  Test passes locally with docker-compose
-  Fix is minimal and doesn't change test behavior
-  Maintains the SDK name verification logic

---
AI-Generated-By: GitHub Copilot (Claude Sonnet 4.5)