### PR TITLE
fix: Push version bump commit to main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -120,6 +120,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add pyproject.toml
           git commit -m "chore: bump version to v${{ steps.bump.outputs.version }}"
+          git push origin HEAD:main
 
       - name: Create and push tag
         run: |


### PR DESCRIPTION
## Problem
The version-bump workflow creates version bump commits and tags, but **only pushes the tags**. The commit updating `pyproject.toml` never gets pushed to main, causing version drift.

This required manual sync PR #61.

## Solution  
Added `git push origin HEAD:main` after the commit step.

## Testing
After merge, the next PR to main will test:
-  Tag created
-  GitHub Release created  
-  `pyproject.toml` on main updated (NEW - this was broken)

## Note
Main is not protected, so workflow can push. Once branch protection is enabled, will need a PAT instead of GITHUB_TOKEN.

## Reminder
@vcaboara asked to be reminded: **Try using lovable.dev to design company logos**