### PR TITLE
[AI] chore: Version bump to v0.14.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "job-lead-starter"
-version = "0.14.0"
+version = "0.14.1"
 description = "Minimal, modular job-finder starter with Gemini template and CI"
 requires-python = ">=3.12"
 dependencies = [


### PR DESCRIPTION
Automated version bump after merging PR #108.

**Changes:**
- Bumped version from v0.14.0 to v0.14.1  
- Created release tag v0.14.1

**PR #108**: Fix dashboard service status: CORS headers and MCP health checks

**Merge Instructions:**
This PR can be merged immediately as it only updates the version number in \pyproject.toml\.

---
AI-Generated-By: GitHub Copilot (Claude Sonnet 4.5)