### PR TITLE
[AI] fix: Prevent version bump workflow infinite loop

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -7,7 +7,10 @@ on:
 
 jobs:
   bump-version:
-    if: github.event.pull_request.merged == true
+    # Skip if PR is itself a version bump (prevent infinite loop)
+    if: |
+      github.event.pull_request.merged == true &&
+      !startsWith(github.event.pull_request.head.ref, 'auto/version-bump-')
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
## Problem

Version bump workflow was triggering on its own PRs, creating infinite loop:
1. PR #108 merged  workflow created PR #110 (v0.14.1) 
2. PR #110 merged  workflow created PR #111 (v0.14.2)  **WRONG**
3. If PR #111 merged  would create v0.14.3, v0.14.4, ... infinitely 

## Root Cause

Workflow triggers on **all** merged PRs to main, including version bump PRs themselves.

## Fix

Added condition to skip workflow if PR branch starts with \uto/version-bump-\:

\\\yaml
if: |
  github.event.pull_request.merged == true &&
  !startsWith(github.event.pull_request.head.ref, 'auto/version-bump-')
\\\

## Verification

- Closed erroneous PR #111
- Deleted branch \uto/version-bump-v0.14.2\
- Version remains at v0.14.1 (correct)

---
AI-Generated-By: GitHub Copilot (Claude Sonnet 4.5)