### PR TITLE
[AI] fix: Version bump workflow to commit directly to main

### DIFF
--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -10,11 +10,11 @@ jobs:
     # Skip if PR is itself a version bump (prevent infinite loop)
     if: |
       github.event.pull_request.merged == true &&
-      !startsWith(github.event.pull_request.head.ref, 'auto/version-bump-')
+      !startsWith(github.event.pull_request.head.ref, 'auto/version-bump-') &&
+      !contains(github.event.pull_request.title, 'chore: bump version')
     runs-on: ubuntu-latest
     permissions:
       contents: write
-      pull-requests: write
 
     steps:
       - uses: actions/checkout@v4
@@ -117,11 +117,17 @@ jobs:
             echo "EOF"
           } >> $GITHUB_OUTPUT
 
-      - name: Commit version bump
+      - name: Commit and push version bump directly to main
         id: commit
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Checkout main and ensure it's up to date
+          git checkout main
+          git pull origin main
+
+          # Apply version change
           git add pyproject.toml
           git commit -m "[AI] chore: bump version to v${{ steps.bump.outputs.version }}
 
@@ -130,8 +136,8 @@ jobs:
           ---
           AI-Generated-By: GitHub Actions Bot"
 
-          # Save commit SHA for PR creation
-          echo "commit_sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+          # Push directly to main
+          git push origin main
 
       - name: Create and push tag
         run: |
@@ -146,38 +152,8 @@ jobs:
           # Create new annotated tag
           git tag -a "$TAG_NAME" -m "Release $TAG_NAME: ${{ github.event.pull_request.title }}"
 
-          # Push tag directly (tags bypass branch protection)
+          # Push tag
           git push origin "$TAG_NAME"
-
-      - name: Create version bump PR
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          # Create a new branch for version bump
-          BRANCH_NAME="auto/version-bump-v${{ steps.bump.outputs.version }}"
-          git checkout -b "$BRANCH_NAME"
-
-          # Push the branch
-          git push origin "$BRANCH_NAME"
-
-          # Create PR
-          gh pr create \
-            --title "[AI] chore: Version bump to v${{ steps.bump.outputs.version }}" \
-            --body "Automated version bump after merging PR #${{ github.event.pull_request.number }}.
-
-          **Changes:**
-          - Bumped version from v${{ steps.bump.outputs.old_version }} to v${{ steps.bump.outputs.version }}
-          - Created release tag v${{ steps.bump.outputs.version }}
-
-          **Merge Instructions:**
-          This PR can be merged immediately as it only updates the version number in \`pyproject.toml\`.
-
-          ---
-          AI-Generated-By: GitHub Actions Bot" \
-            --base main \
-            --head "$BRANCH_NAME" \
-            --label "automation" \
-            --label "version-bump"
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2


### PR DESCRIPTION
## Problem

The version bump workflow was creating PRs but failing with permissions error:
\\\
github-actions[bot] does not have permission to update the pull request
\\\

This happened on every PR merge, creating failed CI checks and orphaned PRs.

## Solution

Changed the workflow to commit version bumps **directly to main** instead of creating PRs:
-  Eliminates permissions errors
-  Simplifies workflow (version bumps are mechanical, don't need review)
-  Prevents infinite loops with additional title check
-  Still creates tags and GitHub releases

## Changes

1. **Removed PR creation step** - was failing with permissions
2. **Added direct push to main** - checkout main, commit, push
3. **Added title check** - skip if PR title contains 'chore: bump version'
4. **Removed \pull-requests: write\** - no longer needed

## Testing

After merge, the next PR merge will trigger this workflow and:
- Commit version bump directly to main
- Create a tag (e.g., v0.14.2)  
- Create a GitHub release

No PR will be created, no permissions error will occur.

Fixes #116

---
AI-Generated-By: GitHub Copilot (Claude Sonnet 4.5)