### PR TITLE
[AI] fix: Remove port 3001 Vibe Kanban checks

### DIFF
--- a/src/app/templates/dashboard.html
+++ b/src/app/templates/dashboard.html
@@ -322,8 +322,8 @@
                     Task management board for autonomous AI execution. Track progress and status.
                 </div>
                 <span class="service-status running" id="kanban-status" aria-live="polite"
-                    aria-atomic="true">Checking...</span>
-                <a href="http://localhost:3001" class="service-link" target="_blank">View Board →</a>
+                    aria-atomic="true">Available</span>
+                <a href="/visual-kanban" class="service-link">View Board →</a>
             </div>
 
             <div class="service-card">
@@ -486,9 +486,9 @@
 
         async function updateTaskCount() {
             try {
-                const response = await fetch('http://localhost:3001/api/tasks');
-                const tasks = await response.json();
-                const activeTasks = Array.isArray(tasks) ? tasks.filter(t => t.status === TASK_STATUS.IN_PROGRESS || t.status === TASK_STATUS.TODO).length : 0;
+                const response = await fetch('/api/kanban/tasks');
+                const data = await response.json();
+                const activeTasks = Array.isArray(data.tasks) ? data.tasks.filter(t => t.status === 'in_progress' || t.status === 'todo').length : 0;
                 document.getElementById('active-tasks').textContent = activeTasks;
             } catch (error) {
                 document.getElementById('active-tasks').textContent = '0';
@@ -505,7 +505,6 @@
             await updateTaskCount();
             checkServiceStatus('http://localhost:8000', 'ui-status');
             checkServiceStatus('http://localhost:9000', 'monitor-status');
-            checkServiceStatus('http://localhost:3001', 'kanban-status');
             checkServiceStatus('http://localhost:3000', 'vibe-status', true); // MCP service, accept 404
         }
 


### PR DESCRIPTION
## Problem
Dashboard was checking for Vibe Kanban service on port 3001, showing it as 'stopped'.

## Root Cause
Vibe Kanban is not a separate service - it's a UI route at /visual-kanban on the main UI server (port 8000).

## Changes
- Updated service card link: http://localhost:3001  /visual-kanban
- Removed port 3001 from service status checks
- Updated task count API: http://localhost:3001/api/tasks  /api/kanban/tasks
- Changed status display to 'Available' (static, no service check needed)

## Result
Dashboard no longer reports Vibe Kanban as 'stopped'. Link correctly navigates to visual kanban board.

---
AI-Generated-By: GitHub Copilot (Claude Sonnet 4.5)