### PR TITLE
[AI] fix: Remove duplicate Kanban service card

### DIFF
--- a/src/app/templates/dashboard.html
+++ b/src/app/templates/dashboard.html
@@ -316,13 +316,12 @@
             <div class="service-card">
                 <div class="service-header">
                     <div class="service-icon">📋</div>
-                    <div class="service-title">Vibe Kanban</div>
+                    <div class="service-title">Visual Kanban Board</div>
                 </div>
                 <div class="service-description">
-                    Task management board for autonomous AI execution. Track progress and status.
+                    Task management board for autonomous AI execution. Track progress and status in real-time.
                 </div>
-                <span class="service-status running" id="kanban-status" aria-live="polite"
-                    aria-atomic="true">Available</span>
+                <span class="service-status running">Available</span>
                 <a href="/visual-kanban" class="service-link">View Board →</a>
             </div>
 
@@ -337,18 +336,6 @@
                 <span class="service-status running" id="vibe-status" aria-live="polite"
                     aria-atomic="true">Checking...</span>
                 <a href="http://localhost:3000" class="service-link" target="_blank">View Checks →</a>
-            </div>
-
-            <div class="service-card">
-                <div class="service-header">
-                    <div class="service-icon">🎨</div>
-                    <div class="service-title">Visual Kanban Board</div>
-                </div>
-                <div class="service-description">
-                    Human-friendly visual Kanban board to observe autonomous AI progress.
-                </div>
-                <span class="service-status running">Local</span>
-                <a href="/visual-kanban" class="service-link">View Board →</a>
             </div>
 
             <div class="service-card">


### PR DESCRIPTION
## Problem
Dashboard had two service cards for the same Kanban board:
- 'Vibe Kanban' ()
- 'Visual Kanban Board' ()

Both linked to /visual-kanban - they were duplicates.

## Root Cause
Documentation confusion led to believing 'Vibe Kanban' was a separate MCP service on port 3001. It was never a separate service.

## Changes
- Removed duplicate 'Vibe Kanban' card
- Kept 'Visual Kanban Board' with enhanced description
- Single card now represents the /visual-kanban route

## Result
Cleaner dashboard with no redundant service cards.

---
AI-Generated-By: GitHub Copilot (Claude Sonnet 4.5)