### PR TITLE
[AI] chore: bump version to v0.14.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "job-lead-starter"
-version = "0.14.12"
+version = "0.14.13"
 description = "Minimal, modular job-finder starter with Gemini template and CI"
 requires-python = ">=3.12"
 dependencies = [ "python-dotenv>=0.21.0", "beautifulsoup4>=4.12.0", "httpx>=0.25.0", "defusedxml>=0.7.0", "pypdf>=4.0.0", "python-docx>=1.0.0", "apscheduler>=3.10.0",]


### PR DESCRIPTION
Automated version bump after merging PR #142.

**Changes:**
- Bumped version from v0.14.12 to v0.14.13
- Created release tag v0.14.13

**Status:**
This PR will auto-merge once CI checks pass.

---
AI-Generated-By: GitHub Actions Bot