### PR TITLE
fix: remove redundant local logger in search_jobs, drop empty test

### DIFF
--- a/src/app/mcp_providers.py
+++ b/src/app/mcp_providers.py
@@ -761,8 +761,6 @@ class MCPAggregator:
             # Filter to requested providers
             available = [p for p in available if p.name in providers]
 
-        logger = logging.getLogger(__name__)
-
         if not available:
             logger.warning("No MCP providers available")
             return []

--- a/tests/test_verify_version_auto_merge.py
+++ b/tests/test_verify_version_auto_merge.py
@@ -345,16 +345,6 @@ class TestIntegrationWorkflow:
         assert old_version == current_version
         assert f'version = "{new_version}"' in updated_content
 
-    @patch("subprocess.run")
-    def test_github_cli_availability_check(self, mock_subprocess):
-        """Test GitHub CLI availability detection."""
-        # Mock successful gh command
-        mock_subprocess.return_value.stdout = "gh version 2.40.1"
-
-        # This would normally be tested in the main function
-        # We'll test the logic indirectly through imports
-        pass  # Integration test logic verified manually
-
 
 if __name__ == "__main__":
     pytest.main([__file__])


### PR DESCRIPTION
## Summary

- Remove `logger = logging.getLogger(__name__)` inside `MCPAggregator.search_jobs` — the module-level logger added in #159 already covers this scope; the local redefinition was redundant
- Delete `test_github_cli_availability_check` from `test_verify_version_auto_merge.py` — it had a `pass`-only body and tested nothing (always passed regardless of behavior)

## Test plan

- [ ] 426 tests pass (`uv run pytest`) — one fewer than before, which is the removed empty test